### PR TITLE
add functionality to convert numeric fields to string

### DIFF
--- a/fluent-plugin-serialize-nested-json.gemspec
+++ b/fluent-plugin-serialize-nested-json.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-serialize-nested-json"
-  spec.version       = "0.0.1"
+  spec.version       = "0.0.2"
   spec.authors       = ["Yagnesh Mistry"]
   spec.email         = ["ysh@live.in"]
   spec.description   = %q{Parser plugin that serializes nested JSON attributes}

--- a/lib/fluent/plugin/parser_serialize_nested_json.rb
+++ b/lib/fluent/plugin/parser_serialize_nested_json.rb
@@ -6,6 +6,7 @@ module Fluent
     class SerializeJSONParser < Parser
       Plugin.register_parser('serialize_nested_json', self)
 
+      config_param :stringify_num, :bool, default: "false"   # strinfify_num is configurable with "false" as default
       config_set_default :time_key, 'time'
       config_set_default :time_type, :float
 
@@ -29,6 +30,13 @@ module Fluent
               record.delete k
             rescue Exception => e
               # continue
+            end
+          end
+          if v.is_a?(Numeric) && @strinfify_num == true
+            begin
+              values[k] = v.to_s
+              record.delete k
+            rescue Exception => e
             end
           end
         end


### PR DESCRIPTION
when in the config 

stringify_num: true

is passed, the plugin will convert the all-numeric field to string.